### PR TITLE
Main Homepage Upgrade owo

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,7 @@
   <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
     <!-- Dishes Card -->
     <div
-      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer bg-white/10 border border-white/10 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/20 flex flex-col h-full"
       role="link"
       tabindex="0"
       on:click={() => goto('/dishes')}
@@ -42,14 +42,14 @@
           Browse all {dishes.length} dishes with detailed information about levels, prices, and requirements
         </p>
       </div>
-      <a href="/dishes" class="btn variant-filled-primary w-full">
+      <button type="button" class="btn btn-lg preset-filled w-full mt-auto" on:click={() => goto('/dishes')}>
         View All Dishes
-      </a>
+      </button>
     </div>
 
     <!-- Ingredients Card -->
     <div
-      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer bg-white/10 border border-white/10 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/20 flex flex-col h-full"
       role="link"
       tabindex="0"
       on:click={() => goto('/ingredients')}
@@ -66,14 +66,14 @@
           Explore all {ingredients.length} ingredients with source locations, types, and gathering information
         </p>
       </div>
-      <a href="/ingredients" class="btn variant-filled-secondary w-full">
+      <button type="button" class="btn btn-lg preset-filled w-full mt-auto" on:click={() => goto('/ingredients')}>
         View All Ingredients
-      </a>
+      </button>
     </div>
 
     <!-- Parties Card -->
     <div
-      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer bg-white/10 border border-white/10 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/20 flex flex-col h-full"
       role="link"
       tabindex="0"
       on:click={() => goto('/parties')}
@@ -90,9 +90,9 @@
           Discover all {parties.length} party events with bonuses and associated dishes
         </p>
       </div>
-      <a href="/parties" class="btn variant-filled-tertiary w-full">
+      <button type="button" class="btn btn-lg preset-filled w-full mt-auto" on:click={() => goto('/parties')}>
         View All Parties
-      </a>
+      </button>
     </div>
   </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PageData } from './$types.js';
+  import { goto } from '$app/navigation';
 
   export let data: PageData;
 
@@ -23,7 +24,13 @@
 
   <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
     <!-- Dishes Card -->
-    <div class="card variant-glass-surface p-8 text-center">
+    <div
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      role="link"
+      tabindex="0"
+      on:click={() => goto('/dishes')}
+      on:keydown={(e) => e.key === 'Enter' && goto('/dishes')}
+    >
       <div class="mb-6">
         <div class="w-16 h-16 bg-primary-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
           <svg class="w-8 h-8 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -41,7 +48,13 @@
     </div>
 
     <!-- Ingredients Card -->
-    <div class="card variant-glass-surface p-8 text-center">
+    <div
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      role="link"
+      tabindex="0"
+      on:click={() => goto('/ingredients')}
+      on:keydown={(e) => e.key === 'Enter' && goto('/ingredients')}
+    >
       <div class="mb-6">
         <div class="w-16 h-16 bg-secondary-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
           <svg class="w-8 h-8 text-secondary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -59,7 +72,13 @@
     </div>
 
     <!-- Parties Card -->
-    <div class="card variant-glass-surface p-8 text-center">
+    <div
+      class="card variant-glass-surface p-8 text-center rounded-xl shadow-md hover:shadow-xl transition cursor-pointer"
+      role="link"
+      tabindex="0"
+      on:click={() => goto('/parties')}
+      on:keydown={(e) => e.key === 'Enter' && goto('/parties')}
+    >
       <div class="mb-6">
         <div class="w-16 h-16 bg-tertiary-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
           <svg class="w-8 h-8 text-tertiary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
# Home: Convert feature tiles into clickable cards, lighten surfaces, and add large filled CTAs

## Summary
UI-only refresh of the homepage hero tiles:
- Each tile is now a distinct “card” with a lighter surface and soft border.
- Clear primary CTAs using Skeleton’s large filled buttons.
- Full-card click target with keyboard support.
- Aligned CTA baselines across columns.

## Changes
- `src/routes/+page.svelte`
  - Made each tile a card with lighter surface:
    - `bg-white/10 border border-white/10 backdrop-blur-sm rounded-xl shadow-md hover:shadow-xl transition`
  - Whole-card navigation:
    - `on:click` + `role="link"` + `tabindex="0"` + `Enter` key handling via `goto(...)`
  - Replaced links with Skeleton buttons per guidance:
    - `button.btn.btn-lg.preset-filled.w-full.mt-auto`
    - Reference: [Skeleton Buttons](https://www.skeleton.dev/docs/tailwind/buttons)
  - Ensured baseline alignment:
    - Cards use `flex flex-col h-full`, CTAs use `mt-auto`

No data, server, or calc logic touched.

## Why
- Improve scannability and affordance.
- Make CTAs consistent, accessible, and obvious.
- Small, isolated UI edits as requested.

## Screenshots
- Before/after: see local run; visual-only change.

## Accessibility
- Keyboard: cards focusable, `Enter` activates; buttons are native.
- Focus ring preserved via Skeleton + default outlines.

## How to test
1. `npm run dev`
2. Verify:
   - Cards are visually distinct from the background.
   - Clicking anywhere on a card navigates to the correct page.
   - CTA buttons are large, filled, and full-width.
   - All three CTAs sit on the same horizontal baseline.
   - Keyboard: `Tab` to card or button, `Enter` navigates.

## Risks / Rollback
- Low risk; limited to `src/routes/+page.svelte` and Tailwind/Skeleton classes.
- Rollback by reverting that file’s edits.
